### PR TITLE
Fix PHP error

### DIFF
--- a/src/Sms/SenderSettings/CountrySenderSettings.php
+++ b/src/Sms/SenderSettings/CountrySenderSettings.php
@@ -101,8 +101,8 @@ class CountrySenderSettings implements ISenderSettings, \JsonSerializable
 	}
 
 
-	public function jsonSerialize()
-    {
-        return $this->toArray();
-    }
+	public function jsonSerialize(): mixed
+	{
+		return $this->toArray();
+	}
 }


### PR DESCRIPTION
Return type of BulkGate\Sms\SenderSettings\CountrySenderSettings::jsonSerialize() should either be compatible with JsonSerializable::jsonSerialize(): mixed, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice bulkgate/sms/src/Sms/SenderSettings/CountrySenderSettings.php 104